### PR TITLE
Fixed incorrect numbering of pinned tabs.

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,4 +1,7 @@
 @-moz-document url-prefix("chrome:") {
+  #vertical-pinned-tabs-container > .zen-workspace-tabs-section[hidden="true"] {
+    display: none !important;
+  }
   tabs {
     counter-reset: tab-counter;
   } /* Automatically increment tab numbers for each .tab-content inside a tab */ /* Styles when the sidebar is expanded */


### PR DESCRIPTION
In this pull request, I have fixed the incorrect numbering of pinned tabs by fully hiding other pinned tab workspaces with a high enough specificity so that it can overwrite SuperPins display properties.