### PR TITLE
Fix Tab Number Counting Across Workspaces

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -43,7 +43,7 @@
     }
 
     /*  Hide tab numbers on the right side when hovering over */
-    tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content:hover::after {
+    .zen-workspace-tabs-section tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content:hover::after {
       opacity: 0; /* Make it invisible */
       width: 0; /* In order to bring the close button to the right */
       margin: 0;

--- a/chrome.css
+++ b/chrome.css
@@ -6,7 +6,7 @@
     counter-reset: tab-counter;
   } /* Automatically increment tab numbers for each .tab-content inside a tab */ /* Styles when the sidebar is expanded */
   @media (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
+    .zen-workspace-tabs-section[active="true"] tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
       counter-increment: tab-counter;
       content: counter(
         tab-counter
@@ -60,7 +60,7 @@
       tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
         display: none; /* Hide the ::after pseudo-element first */
       }
-      tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
+      .zen-workspace-tabs-section[active="true"] tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
         counter-increment: tab-counter;
         content: counter(
           tab-counter
@@ -88,7 +88,7 @@
     }
   } /* Styles when the sidebar is NOT expanded (compact mode) */
   @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
+    .zen-workspace-tabs-section[active="true"] tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
       counter-increment: tab-counter;
       content: counter(tab-counter) "";
       position: absolute;
@@ -104,7 +104,7 @@
       color: var(--number_color, inherit); /* Fallback to default color */
     } /* Put tab numbers on the left side when compact_side="Left" (AND in compact mode) */
     :root:has(#theme-Tab-Numbers[uc-theme-compact_side="Left"]) {
-      tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
+      .zen-workspace-tabs-section[active="true"] tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
         counter-increment: tab-counter;
         content: counter(tab-counter) "";
         position: absolute;


### PR DESCRIPTION
Made a quick fix to the tab numbering. The problem was that the tab counter didn't reset when switching workspaces, so the numbers would just keep counting up across different sections (e.g., Workspace 1 ends at tab 5, Workspace 2 would start counting from 6).
I added `.zen-workspace-tabs-section[active="true"]` to the selectors responsible for the numbers (`::after` and `::before`). This makes sure the counter only increments within the active workspace. Now, each workspace should correctly start its numbering from 1. 👍