### PR TITLE
fix: tab counter increment logic

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -4,9 +4,11 @@
 tabs {
   counter-reset: tab-counter;
 } /* Automatically increment tab numbers for each .tab-content inside a tab */ /* Styles when the sidebar is expanded */
+tab:not([hidden]):not([zen-glance-tab="true"]) {
+  counter-increment: tab-counter;
+}
 @media (-moz-bool-pref: "zen.view.sidebar-expanded") {
   tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
-    counter-increment: tab-counter;
     content: counter(
       tab-counter
     ); /* Space before the number */ /* Positioning and styling */
@@ -60,7 +62,6 @@ tabs {
       display: none; /* Hide the ::after pseudo-element first */
     }
     tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
-      counter-increment: tab-counter;
       content: counter(
         tab-counter
       ); /* Space before the number */ /* Positioning and styling */
@@ -88,7 +89,6 @@ tabs {
 } /* Styles when the sidebar is NOT expanded (compact mode) */
 @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
   tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
-    counter-increment: tab-counter;
     content: counter(tab-counter) "";
     position: absolute;
     top: 4px;
@@ -101,7 +101,6 @@ tabs {
   } /* Put tab numbers on the left side when compact_side="Left" (AND in compact mode) */
   :root:has(#theme-Tab-Numbers[uc-theme-compact_side="Left"]) {
     tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
-      counter-increment: tab-counter;
       content: counter(tab-counter) "";
       position: absolute;
       top: 4px;


### PR DESCRIPTION
Moves the `counter-increment` property to the `tab` element itself.

This ensures that the tab counter is correctly incremented for all non hidden and non glance tabs.

closes #7 

<img width="316" alt="Screenshot 2025-06-23 at 13 20 54" src="https://github.com/user-attachments/assets/95209015-4c92-4125-bd1f-9386f77e23a0" />

Tested on 1.13.2b (Firefox 139.0.4) (aarch64)