### PR TITLE
fixed tab number overlapping with pinned tab icon

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -51,6 +51,15 @@ zen-workspace[active] tab:not([zen-glance-tab="true"]) {
     margin: 0;
   }
 
+  /* Hide the second icon when tab is pinned */
+  [zen-pinned-changed='true']:not([zen-essential]) .tab-reset-pin-button image {
+    opacity: 1 !important;
+  }
+  
+  [zen-pinned-changed='true']:not([zen-essential]) .tab-icon-image {
+    opacity: 0 !important;
+  }
+
   /* Show the "X" close button on hover */
   tab:hover .tab-close-button {
     visibility: visible;


### PR DESCRIPTION
### Fixed an issue where tab number is overlapping with pinned tab icon 
<img width="231" height="330" alt="image" src="https://github.com/user-attachments/assets/e57dddcf-0a11-4b89-aedc-c88e4042f789" />
<br><br>

this issue happen when we browse through the pinned tab. For example if I pin reddit.com, the tab number is working fine until  I open a reddit post  which will make the url is not just reddit.com anymore.<br>

<img width="230" height="230" alt="image" src="https://github.com/user-attachments/assets/925804c4-1333-4f94-81f7-4b2e61766771" /><br>


Zen will change the `.tab-icon-stack` position attribute to `absolute` , which will make the tab number overlap with the button icon

### Solution

```css
[zen-pinned-changed='true']:not([zen-essential]) .tab-reset-pin-button image {
  opacity: 1 !important;
}

[zen-pinned-changed='true']:not([zen-essential]) .tab-icon-image {
  opacity: 0 !important;
}
```

this will display the button img and just hide the pinned tab icon. 

sorry for bad English or bad code. This is my first time trying to fork and try to fix smth
